### PR TITLE
PHP 8.2: ${var} string interpolation deprecated

### DIFF
--- a/valkey-stats.php
+++ b/valkey-stats.php
@@ -676,7 +676,7 @@ else
 	<h2>Used Memory</h2>
 
 	<div class="key"><?php echo $data['used_memory_human'] ?></div>
-	<?php if ($data['maxmemory'] > 0) echo "/ ${data['maxmemory_human']}\n"; ?>
+	<?php if ($data['maxmemory'] > 0) echo "/ {$data['maxmemory_human']}\n"; ?>
 	<h2>Peak Memory</h2>
 	<div class="key"><?php echo $data['used_memory_peak_human'] ?></div>
 </div>


### PR DESCRIPTION
https://php.watch/versions/8.2/$%7Bvar%7D-string-interpolation-deprecated